### PR TITLE
Bugfixes/Remove transport pause delay

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -305,17 +305,27 @@ Socket.prototype.probe = function (name) {
       var upgradeLosesBinary = !this.supportsBinary && self.transport.supportsBinary;
       failed = failed || upgradeLosesBinary;
     }
-    if (failed) self.emit('upgradeError', err);;
+
+    if (failed) {
+      self.emit('upgradeError', err);
+      return;
+    }
 
     debug('probe transport "%s" opened', name);
     transport.send([{ type: 'ping', data: 'probe' }]);
     transport.once('packet', function (msg) {
-      if (failed) self.emit('upgradeError', err);;
+      if (failed) if (failed) {
+        self.emit('upgradeError', err);
+        return;
+      }
       if ('pong' === msg.type && 'probe' === msg.data) {
         debug('probe transport "%s" pong', name);
         self.upgrading = true;
         self.emit('upgrading', transport);
-        if (!transport) self.emit('upgradeError', err);;
+        if (!transport) {
+          self.emit('upgradeError', err);
+          return;
+        }
         Socket.priorWebsocketSuccess = 'websocket' === transport.name;
 
         // debug('pausing current transport "%s"', self.transport.name);

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -56,8 +56,8 @@ function Socket (uri, opts) {
   this.hostname = opts.hostname ||
     (typeof location !== 'undefined' ? location.hostname : 'localhost');
   this.port = opts.port || (typeof location !== 'undefined' && location.port
-      ? location.port
-      : (this.secure ? 443 : 80));
+    ? location.port
+    : (this.secure ? 443 : 80));
   this.query = opts.query || {};
   if ('string' === typeof this.query) this.query = parseqs.decode(this.query);
   this.upgrade = false !== opts.upgrade;
@@ -305,23 +305,23 @@ Socket.prototype.probe = function (name) {
       var upgradeLosesBinary = !this.supportsBinary && self.transport.supportsBinary;
       failed = failed || upgradeLosesBinary;
     }
-    if (failed) return;
+    if (failed) self.emit('upgradeError', err);;
 
     debug('probe transport "%s" opened', name);
     transport.send([{ type: 'ping', data: 'probe' }]);
     transport.once('packet', function (msg) {
-      if (failed) return;
+      if (failed) self.emit('upgradeError', err);;
       if ('pong' === msg.type && 'probe' === msg.data) {
         debug('probe transport "%s" pong', name);
         self.upgrading = true;
         self.emit('upgrading', transport);
-        if (!transport) return;
+        if (!transport) self.emit('upgradeError', err);;
         Socket.priorWebsocketSuccess = 'websocket' === transport.name;
 
-        debug('pausing current transport "%s"', self.transport.name);
-        self.transport.pause(function () {
-          if (failed) return;
-          if ('closed' === self.readyState) return;
+        // debug('pausing current transport "%s"', self.transport.name);
+        // self.transport.pause(function () {
+          // if (failed) return;
+          // if ('closed' === self.readyState) return;
           debug('changing transport and sending upgrade packet');
 
           cleanup();
@@ -332,7 +332,7 @@ Socket.prototype.probe = function (name) {
           transport = null;
           self.upgrading = false;
           self.flush();
-        });
+        // });
       } else {
         debug('probe transport "%s" failed', name);
         var err = new Error('probe error');
@@ -414,6 +414,12 @@ Socket.prototype.onOpen = function () {
   Socket.priorWebsocketSuccess = 'websocket' === this.transport.name;
   this.emit('open');
   this.flush();
+
+  // Pause the current transport.
+  debug('pausing current transport "%s"', this.transport.name);
+  this.transport.pause(function () {
+    if ('closed' === this.readyState) return;
+  });
 
   // we check for `readyState` in case an `open`
   // listener already closed the socket


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
After Websocket transport is opened, there is a delay in the stopping of the current polling transport method.

### New behaviour
When Websocket transport is opened, the current polling transport method is immediately stopped.

### Other information (e.g. related issues)
This change addresses the connection issue with Safari and multiple server instances. 

